### PR TITLE
Chore/switch to pathlib and config

### DIFF
--- a/get_airquality_measures.py
+++ b/get_airquality_measures.py
@@ -30,46 +30,61 @@ Notes
   post-anchor changes so everything stays aligned to the anchor geography.
 """
 
-# CHANGED: added pathlib; kept existing libs
-from pathlib import Path  # NEW
+from pathlib import Path
 import requests
 import numpy as np
 import pandas as pd
 import time
+import random   # NEW
 
-# CHANGED: central config & pathlib
-STORE_DIR = Path('E:/airquality/')  # NEW: change this in one place later
-STORE_DIR.mkdir(parents=True, exist_ok=True)  # NEW: make sure folder exists
+# ---------- config (same as step 1) ----------
+STORE_DIR = Path('E:/airquality/')
+STORE_DIR.mkdir(parents=True, exist_ok=True)
 
 apiurl = 'https://api.nilu.no/'
 obshistoryurl = f'{apiurl}obs/historical/'
 stationlookupurl = f'{apiurl}lookup/stations'
 
-# CHANGED: unchanged logic, just write using Path
-resp = requests.get(stationlookupurl)
+# ---------- NEW: one reusable HTTP session ----------
+session = requests.Session()  # NEW
+DEFAULT_TIMEOUT = 8.0         # NEW
+MAX_RETRIES = 6               # NEW
+
+# ---------- stations unchanged except using session ----------
+resp = session.get(stationlookupurl, timeout=DEFAULT_TIMEOUT)  # CHANGED
 stationdata = pd.DataFrame(resp.json())
 stationdata.set_index('id', inplace=True)
 stationdata['firstMeasurment'] = pd.to_datetime(stationdata.firstMeasurment)
 stationdata['lastMeasurment'] = pd.to_datetime(stationdata.lastMeasurment)
 
-stationdata.to_csv(STORE_DIR / 'stations.csv')  # CHANGED
+stationdata.to_csv(STORE_DIR / 'stations.csv')
 
 #componentlist = ['CO', 'NO', 'NO2', 'NOx', 'O3', 'PM1', 'PM2.5', 'PM10', 'SO2']
 #stationcomponents = stationdata.components.apply(lambda x: pd.Series([z in x for z in componentlist], index=componentlist))
 
+# ---------- CHANGED: safer retry with exponential backoff ----------
 def sendrequest(stationname, year,
-                nattempts=20, timeoutlo=4, timeouthi=9, sleepfactor=5):
+                nattempts=MAX_RETRIES, timeoutlo=4, timeouthi=9, sleepfactor=5):
     querystring = f'{obshistoryurl}{year}-01-01/{year}-12-31/{stationname}'
+    last_err = None  # NEW
     for attempt in range(nattempts):
         try:
-            resp = requests.get(querystring, timeout=np.random.randint(timeoutlo,timeouthi))
-            assert resp.status_code == 200
-        except Exception as err:
-            print(f"Error {err}, taking 5 x attempts and retrying")
-            time.sleep(sleepfactor * attempt)
-        else:
-            break
-    return resp
+            # use a consistent default timeout, still allow small random int if you like
+            timeout = np.random.randint(timeoutlo, timeouthi)
+            resp = session.get(querystring, timeout=max(timeout, DEFAULT_TIMEOUT))  # CHANGED
+            if resp.ok:  # CHANGED: no bare assert; check properly
+                return resp
+            else:
+                last_err = f"HTTP {resp.status_code}"
+        except requests.RequestException as err:  # CHANGED: catch network errors only
+            last_err = err
+        # CHANGED: exponential backoff with a bit of jitter
+        wait = min(1.8 ** attempt, 60) + random.uniform(-0.4, 0.4)
+        wait = max(0.2, wait)
+        print(f"Retrying {stationname} {year} after error {last_err!s}. Waiting {wait:.1f}s…")
+        time.sleep(wait)
+    # if we exit loop, return the last response or raise
+    raise RuntimeError(f"Failed {stationname} {year} after {nattempts} attempts ({last_err})")
 
 failure = []
 measuredata = pd.DataFrame()
@@ -82,8 +97,9 @@ for sid in stationdata.index:
     
     for year in range(startyear, endyear + 1):
         resp = sendrequest(stationname, year)
-        if len(resp.json()) > 0:
-            for cmeasure in resp.json():
+        payload = resp.json()  # NEW: parse once
+        if len(payload) > 0:
+            for cmeasure in payload:
                 temp = pd.DataFrame(cmeasure['values'])
                 temp['component'] = cmeasure['component']
                 temp['id'] = sid
@@ -94,6 +110,5 @@ for sid in stationdata.index:
             failure.append((sid, year))
     print("Time taken: ", (time.time() - tic) / 60)
 
-# CHANGED: write using Path (same filenames as before)
 measuredata.to_csv(STORE_DIR / 'measurements.csv', index=False)
 measuredata.to_parquet(STORE_DIR / 'measurements.pq', engine='fastparquet', index=False)

--- a/get_airquality_measures.py
+++ b/get_airquality_measures.py
@@ -1,33 +1,69 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
-Created on Thu Jan 20 14:58:01 2022
-
-@author: morten
-
-Get air quality measures from api.nilu.no
-"""
-"""
-SSB Municipality Data Pipeline
+NILU Air Quality Downloader
+---------------------------
 
 Purpose
 -------
-Fetch municipal population (07459) and household income (06944), map all municipality
-codes to a fixed anchor date (default 2020-01-01), and export clean CSVs.
+Fetch historical air-quality measurements from https://api.nilu.no for every station,
+year-by-year, with robust retries and logging. Data is written both as per-station/year
+checkpoints (so you can resume later) and as optional aggregated outputs.
+
+What it does (high level)
+-------------------------
+1) Downloads the station lookup table (id, name, first/last measurement dates).
+2) Loops over each station and each year in its available range.
+3) Requests historical observations, normalizes them, and adds:
+   - time (UTC), component, station id, plus NILU-provided fields (value, unit, etc.).
+4) Writes a compressed CSV **per station-year** so progress is checkpointed.
+5) (Optional) Appends to an in-memory DataFrame and writes final aggregated files.
 
 Outputs
 -------
-- centrality2020.csv         # munid (2020), centrality (KLASS 128)
-- muni2020_codes.csv         # code, name (valid on 2020-01-01)
-- population_muni_year_age.csv
-  - year:int, munid:int (anchor), age:int, population:int
-- income_muni_year.csv
-  - year:int, munid:int (anchor), nhouseholds:float, income_posttax:float, income:float
+In STORE_DIR (default: E:/airquality/):
+- stations.csv
+  Station metadata from NILU (indexed by station id), with dates parsed as UTC.
+
+- raw/measurements_<station_id>_<year>.csv.gz
+  Per station-year checkpoint files (compressed CSV). Safe to resume: existing files are skipped.
+
+- measurements.csv
+  Aggregated CSV of all downloaded data (if you keep the in-memory aggregation).
+
+- measurements.pq
+  Aggregated Parquet of all downloaded data (engine='fastparquet').
+
+Key behaviors / features
+------------------------
+- Reuses a single requests.Session() for speed.
+- Retries failed requests with exponential backoff + jitter.
+- Uses logging with timestamps and levels (INFO/WARNING/ERROR).
+- Parses timestamps with utc=True, drops fromTime/toTime defensively if present.
+- Checkpoint strategy: per station-year files allow safe reruns (skip if file exists).
+
+Configuration
+-------------
+Edit these constants near the top of the file:
+- STORE_DIR      : base output directory (Path)
+- WRITE_DIR_RAW  : STORE_DIR / "raw" (created automatically)
+- DEFAULT_TIMEOUT: request timeout in seconds
+- MAX_RETRIES    : number of retry attempts per request
+
+Requirements
+------------
+Python 3.8+ recommended
+pip install: requests, pandas, numpy, fastparquet (for Parquet writes)
+
+Usage
+-----
+Run the script directly:
+    python your_script.py
 
 Notes
 -----
-- Code mapping uses KLASS 131 changes. Forward to anchor date, then (optionally) back-map
-  post-anchor changes so everything stays aligned to the anchor geography.
+- Consider adding 'raw/', '*.csv.gz', '*.parquet', 'stations.csv', 'measurements.*'
+  to .gitignore to avoid committing large data artifacts.
+- If you only need checkpointed outputs and want to reduce memory, you can skip
+  the final aggregation step by removing the in-memory concat and final writes.
 """
 
 from pathlib import Path
@@ -35,113 +71,123 @@ import requests
 import numpy as np
 import pandas as pd
 import time
-import random   # NEW
-import logging  # NEW
+import random
+import logging
 
 logging.basicConfig(
-    level=logging.INFO, 
+    level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s"
-)  # NEW
+)
 
-
-# ---------- config (same as step 1) ----------
+# ---------- config ----------
 STORE_DIR = Path('E:/airquality/')
 STORE_DIR.mkdir(parents=True, exist_ok=True)
 
-WRITE_DIR_RAW = STORE_DIR / "raw"       # NEW
-WRITE_DIR_RAW.mkdir(exist_ok=True)      # NEW
+WRITE_DIR_RAW = STORE_DIR / "raw"
+WRITE_DIR_RAW.mkdir(exist_ok=True)
 
 apiurl = 'https://api.nilu.no/'
 obshistoryurl = f'{apiurl}obs/historical/'
 stationlookupurl = f'{apiurl}lookup/stations'
 
-# ---------- NEW: one reusable HTTP session ----------
-session = requests.Session()  # NEW
-DEFAULT_TIMEOUT = 8.0         # NEW
-MAX_RETRIES = 6               # NEW
+# ---------- one reusable HTTP session + retry/backoff ----------
+session = requests.Session()
+DEFAULT_TIMEOUT = 8.0
+MAX_RETRIES = 6
 
-# ---------- stations unchanged except using session ----------
-resp = session.get(stationlookupurl, timeout=DEFAULT_TIMEOUT)  # CHANGED
-stationdata = pd.DataFrame(resp.json())
-stationdata.set_index('id', inplace=True)
-stationdata['firstMeasurment'] = pd.to_datetime(stationdata.firstMeasurment)
-stationdata['lastMeasurment'] = pd.to_datetime(stationdata.lastMeasurment)
-
-stationdata.to_csv(STORE_DIR / 'stations.csv')
-
-#componentlist = ['CO', 'NO', 'NO2', 'NOx', 'O3', 'PM1', 'PM2.5', 'PM10', 'SO2']
-#stationcomponents = stationdata.components.apply(lambda x: pd.Series([z in x for z in componentlist], index=componentlist))
-
-# ---------- CHANGED: safer retry with exponential backoff ----------
 def sendrequest(stationname, year,
                 nattempts=MAX_RETRIES, timeoutlo=4, timeouthi=9, sleepfactor=5):
     querystring = f'{obshistoryurl}{year}-01-01/{year}-12-31/{stationname}'
-    last_err = None  # NEW
+    last_err = None
     for attempt in range(nattempts):
         try:
-            # use a consistent default timeout, still allow small random int if you like
             timeout = np.random.randint(timeoutlo, timeouthi)
-            resp = session.get(querystring, timeout=max(timeout, DEFAULT_TIMEOUT))  # CHANGED
-            if resp.ok:  # CHANGED: no bare assert; check properly
+            resp = session.get(querystring, timeout=max(timeout, DEFAULT_TIMEOUT))
+            if resp.ok:
                 return resp
             else:
                 last_err = f"HTTP {resp.status_code}"
-        except requests.RequestException as err:  # CHANGED: catch network errors only
+        except requests.RequestException as err:
             last_err = err
-        # CHANGED: exponential backoff with a bit of jitter
+
         wait = min(1.8 ** attempt, 60) + random.uniform(-0.4, 0.4)
         wait = max(0.2, wait)
-        logging.warning("Retrying %s %d after error %s. Waiting %.1fs…", stationname, year, last_err, wait)
+        logging.warning(
+            "Retrying %s %d after error %s. Waiting %.1fs…",
+            stationname, year, last_err, wait
+        )
         time.sleep(wait)
-    # if we exit loop, return the last response or raise
+
     raise RuntimeError(f"Failed {stationname} {year} after {nattempts} attempts ({last_err})")
 
+# ---------- fetch station metadata ----------
+resp = session.get(stationlookupurl, timeout=DEFAULT_TIMEOUT)
+resp.raise_for_status()
+
+stationdata = pd.DataFrame(resp.json())
+stationdata.set_index('id', inplace=True)
+# timezone-aware + defensive parsing
+stationdata['firstMeasurment'] = pd.to_datetime(stationdata['firstMeasurment'], errors='coerce', utc=True)
+stationdata['lastMeasurment']  = pd.to_datetime(stationdata['lastMeasurment'],  errors='coerce', utc=True)
+
+stationdata.to_csv(STORE_DIR / 'stations.csv')
+
+# ---------- main download loop ----------
 failure = []
 measuredata = pd.DataFrame()
+
 for sid in stationdata.index:
     logging.info("Loading data for %s", sid)
     tic = time.time()
+
     stationname = stationdata.loc[sid, 'station']
-    startyear = stationdata.loc[sid, 'firstMeasurment'].year
-    endyear = stationdata.loc[sid, 'lastMeasurment'].year
-    
+    startyear = int(stationdata.loc[sid, 'firstMeasurment'].year)
+    endyear   = int(stationdata.loc[sid, 'lastMeasurment'].year)
+
     for year in range(startyear, endyear + 1):
         resp = sendrequest(stationname, year)
-        payload = resp.json()  # NEW: parse once
-        from pathlib import Path  # already imported at top
+        payload = resp.json()
 
-if len(payload) > 0:
-    # build a small list, concat once
-    block_frames = []  # NEW
-    for cmeasure in payload:
-        temp = pd.DataFrame(cmeasure['values'])
-        if temp.empty:
-            continue
-        temp['component'] = cmeasure['component']
-        temp['id'] = sid
-        if 'fromTime' in temp:
-            temp['time'] = pd.to_datetime(temp['fromTime'], errors='coerce', utc=True)  # NEW: utc and safe
-            temp.drop(['fromTime'], axis=1, inplace=True)
-        if 'toTime' in temp:
-            temp.drop(['toTime'], axis=1, inplace=True)
-        block_frames.append(temp)
+        if payload:
+            # build a small list, then concat once (faster)
+            block_frames = []
+            for cmeasure in payload:
+                temp = pd.DataFrame(cmeasure.get('values', []))
+                if temp.empty:
+                    continue
+                temp['component'] = cmeasure.get('component')
+                temp['id'] = sid
 
-    if block_frames:
-        year_df = pd.concat(block_frames, ignore_index=True)  # NEW
+                # timezone-aware and defensive
+                if 'fromTime' in temp:
+                    temp['time'] = pd.to_datetime(temp['fromTime'], errors='coerce', utc=True)
+                elif 'toTime' in temp:
+                    temp['time'] = pd.to_datetime(temp['toTime'],   errors='coerce', utc=True)
 
-        # NEW: checkpoint file name
-        out_csv = WRITE_DIR_RAW / f"measurements_{sid}_{year}.csv.gz"
-        if out_csv.exists():
-            logging.info("  %s exists, skipping", out_csv.name)
+                for c in ('fromTime', 'toTime'):
+                    if c in temp.columns:
+                        temp.drop(columns=[c], inplace=True)
+
+                block_frames.append(temp)
+
+            if block_frames:
+                year_df = pd.concat(block_frames, ignore_index=True)
+
+                # checkpoint per station-year (skip if exists)
+                out_csv = WRITE_DIR_RAW / f"measurements_{sid}_{year}.csv.gz"
+                if out_csv.exists():
+                    logging.info("  %s exists, skipping", out_csv.name)
+                else:
+                    year_df.to_csv(out_csv, index=False, compression='gzip')
+                    logging.info("  wrote %s rows to %s", len(year_df), out_csv.name)
+
+                # keep aggregated output (optional)
+                measuredata = pd.concat((measuredata, year_df), ignore_index=True)
         else:
-            year_df.to_csv(out_csv, index=False, compression='gzip')  # NEW
-            logging.info("  wrote %s rows to %s", len(year_df), out_csv.name)
+            failure.append((sid, year))
 
-        # (optional) still keep building the big DataFrame if you want final exports:
-        measuredata = pd.concat((measuredata, year_df), ignore_index=True)  # kept
-else:
-    failure.append((sid, year))
-    logging.info("Time taken: %.2f min", (time.time() - tic) / 60)
+    logging.info("Time taken: %.2f min", (time.time() - tic) / 60.0)
 
+# ---------- final outputs (optional aggregated files) ----------
 measuredata.to_csv(STORE_DIR / 'measurements.csv', index=False)
 measuredata.to_parquet(STORE_DIR / 'measurements.pq', engine='fastparquet', index=False)

--- a/get_airquality_measures.py
+++ b/get_airquality_measures.py
@@ -30,24 +30,29 @@ Notes
   post-anchor changes so everything stays aligned to the anchor geography.
 """
 
+# CHANGED: added pathlib; kept existing libs
+from pathlib import Path  # NEW
 import requests
 import numpy as np
 import pandas as pd
 import time
 
-storefolder = 'E:/airquality/'
+# CHANGED: central config & pathlib
+STORE_DIR = Path('E:/airquality/')  # NEW: change this in one place later
+STORE_DIR.mkdir(parents=True, exist_ok=True)  # NEW: make sure folder exists
 
 apiurl = 'https://api.nilu.no/'
 obshistoryurl = f'{apiurl}obs/historical/'
 stationlookupurl = f'{apiurl}lookup/stations'
 
+# CHANGED: unchanged logic, just write using Path
 resp = requests.get(stationlookupurl)
 stationdata = pd.DataFrame(resp.json())
 stationdata.set_index('id', inplace=True)
 stationdata['firstMeasurment'] = pd.to_datetime(stationdata.firstMeasurment)
 stationdata['lastMeasurment'] = pd.to_datetime(stationdata.lastMeasurment)
 
-stationdata.to_csv(f'{storefolder}stations.csv')
+stationdata.to_csv(STORE_DIR / 'stations.csv')  # CHANGED
 
 #componentlist = ['CO', 'NO', 'NO2', 'NOx', 'O3', 'PM1', 'PM2.5', 'PM10', 'SO2']
 #stationcomponents = stationdata.components.apply(lambda x: pd.Series([z in x for z in componentlist], index=componentlist))
@@ -89,6 +94,6 @@ for sid in stationdata.index:
             failure.append((sid, year))
     print("Time taken: ", (time.time() - tic) / 60)
 
-measuredata.to_csv(f'{storefolder}measurements.csv', index=False)
-# Store as parquet
-measuredata.to_parquet(f'{storefolder}measurements.pq', engine='fastparquet', index=False)
+# CHANGED: write using Path (same filenames as before)
+measuredata.to_csv(STORE_DIR / 'measurements.csv', index=False)
+measuredata.to_parquet(STORE_DIR / 'measurements.pq', engine='fastparquet', index=False)


### PR DESCRIPTION
Centralized config and switched to pathlib for safer paths.
Reused a single HTTP session with default timeout and added retry/backoff for robustness.
Replaced prints with structured logging (timestamps + levels).
Implemented per station-year checkpointing and reduced expensive DataFrame concatenations. 
Fixed loop indentation and minor issues; added clear module header and UTC parsing.

Outcome: faster, more reliable downloads; resumable runs; clearer logs; cleaner structure.