### PR TITLE
Improvements

### DIFF
--- a/get_airquality_measures.py
+++ b/get_airquality_measures.py
@@ -156,10 +156,9 @@ failure = []
 measuredata = pd.DataFrame()
 
 for sid in stationdata.index:
+    stationname = stationdata.loc[sid, 'station']  # define first
     logging.info("Loading data for %s (%s)", sid, stationname)
     tic = time.time()
-
-    stationname = stationdata.loc[sid, 'station']
     startyear = int(stationdata.loc[sid, 'firstMeasurment'].year)
     endyear   = int(stationdata.loc[sid, 'lastMeasurment'].year)
 

--- a/get_airquality_measures.py
+++ b/get_airquality_measures.py
@@ -156,7 +156,7 @@ failure = []
 measuredata = pd.DataFrame()
 
 for sid in stationdata.index:
-    logging.info("Loading data for %s", sid)
+    logging.info("Loading data for %s (%s)", sid, stationname)
     tic = time.time()
 
     stationname = stationdata.loc[sid, 'station']

--- a/get_airquality_measures.py
+++ b/get_airquality_measures.py
@@ -73,6 +73,7 @@ import pandas as pd
 import time
 import random
 import logging
+import os
 
 logging.basicConfig(
     level=logging.INFO,
@@ -80,11 +81,29 @@ logging.basicConfig(
 )
 
 # ---------- config ----------
-STORE_DIR = Path('E:/airquality/')
-STORE_DIR.mkdir(parents=True, exist_ok=True)
+def pick_store_dir() -> Path:
+    """Choose a writable output directory with sensible fallbacks."""
+    candidates = [
+        Path("E:/airquality"),                              # original target (if E: exists)
+        Path.home() / "airquality",                         # e.g., C:\Users\<you>\airquality
+        Path(__file__).resolve().parent / "data" / "airquality",  # inside repo
+    ]
+    for p in candidates:
+        try:
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+        except Exception:
+            continue
+    # last resort: current working directory
+    p = Path.cwd() / "airquality"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
 
+STORE_DIR = pick_store_dir()
 WRITE_DIR_RAW = STORE_DIR / "raw"
 WRITE_DIR_RAW.mkdir(exist_ok=True)
+
+logging.info("Output directory: %s", STORE_DIR)
 
 apiurl = 'https://api.nilu.no/'
 obshistoryurl = f'{apiurl}obs/historical/'


### PR DESCRIPTION
Brief description (what changed & why):

Portable output paths: replaced hard-coded E:/ with pick_store_dir() fallbacks → runs on any machine.

Robust networking: single requests.Session() + default timeout + retry with exponential backoff/jitter → fewer hangs, resilient to transient errors.

Structured logging: swapped print for logging with timestamps; log station id + name and per-station duration → easier to monitor/debug.

Safer parsing: UTC time conversion and defensive drops of fromTime/toTime → consistent timestamps, fewer key errors.

Checkpointing: write raw/measurements_<station>_<year>.csv.gz and skip if exists → resumable runs, no duplicate work.

Reliable aggregation: rebuild measurements.csv (chunked) and measurements.pq from all checkpoints at the end → same final outputs, lower memory use.

Docs: added clear header explaining purpose, outputs, and behavior → future maintenance is simpler.